### PR TITLE
Update alpine version to get latest versions of node and busybox

### DIFF
--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.7
 
 LABEL maintainer "https://github.com/blacktop"
 


### PR DESCRIPTION
Apparently some plugins use fancy features from node 8, so kibana falls over if I install them. Busybox also gets flagged by quay's security check in alpine 3.6. 
Now it passes!
https://quay.io/repository/lalamove/elasticsearch-sg?tab=tags
vs
https://quay.io/repository/lalamove/kibana-sg?tab=tags
Think you could tag up 6.0.0 when you push this change, too? :pray: 