### PR TITLE
Updated node version as otherwise kibana complains

### DIFF
--- a/6.6/Dockerfile
+++ b/6.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.15.1-alpine
+FROM node:10.15.2-alpine
 
 LABEL maintainer "https://github.com/blacktop"
 


### PR DESCRIPTION
I'm getting a

> Kibana does not support the current Node.js version v10.15.1. Please use Node.js v10.15.2.

if I try to install plugins using this image. Updating node version fixed it for me